### PR TITLE
feat: add flexible DAC spindle driver

### DIFF
--- a/FluidNC/src/Spindles/DacSpindle.cpp
+++ b/FluidNC/src/Spindles/DacSpindle.cpp
@@ -1,34 +1,61 @@
-// Copyright (c) 2020 -	Bart Dring
+// Copyright (c) 2020 - Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
 /*
     DacSpindle.cpp
 
-    This uses the Analog DAC in the ESP32 to generate a voltage
-    proportional to the GCode S value desired. Some spindle uses
-    a 0-5V or 0-10V value to control the spindle. You would use
-    an Op Amp type circuit to get from the 0.3.3V of the ESP32 to that voltage.
+    Implements an analogue spindle output capable of driving either the
+    ESP32 internal DAC, an external MCP4822 SPI DAC or a PWM pin with an RC
+    filter. The output voltage is proportional to the requested spindle speed.
 */
-#include <sdkconfig.h>
-#ifdef CONFIG_IDF_TARGET_ESP32
+#include "DacSpindle.h"
 
-#    include "DacSpindle.h"
+#include <cstdint>
 
-#    include <esp32-hal-dac.h>  // dacWrite
+extern void dacWrite(uint8_t pin, uint8_t value);
+
+#include <SPI.h>
 
 namespace Spindles {
     // ======================================== Dac ======================================
     void Dac::init() {
-        if (_output_pin.undefined()) {
-            return;
-        }
+        _gpio_ok = false;
 
-        _gpio_ok = true;
-
-        if (!_output_pin.capabilities().has(Pin::Capabilities::DAC)) {  // DAC can only be used on these pins
-            _gpio_ok = false;
-            log_error("DAC spindle pin invalid " << _output_pin.name().c_str() << " (pin 25 or 26 only)");
-            return;
+        switch (_mode) {
+            case Internal:
+                if (_output_pin.undefined()) {
+                    return;
+                }
+                if (_output_pin.capabilities().has(Pin::Capabilities::DAC)) {
+                    _gpio_ok = true;
+                    setupSpeeds(255);
+                } else {
+                    log_error("DAC spindle pin invalid " << _output_pin.name().c_str() << " (pin 25 or 26 only)");
+                }
+                break;
+            case PWM:
+                if (_output_pin.undefined()) {
+                    log_error("DAC spindle output_pin not defined");
+                    return;
+                }
+                if (_output_pin.capabilities().has(Pin::Capabilities::PWM)) {
+                    _output_pin.setAttr(Pin::Attr::PWM, _pwm_freq);
+                    _gpio_ok = true;
+                    setupSpeeds(_output_pin.maxDuty());
+                } else {
+                    log_error(name() << " output pin " << _output_pin.name().c_str() << " cannot do PWM");
+                }
+                break;
+            case MCP4822:
+                if (_cs_pin.undefined()) {
+                    log_error("DAC spindle cs_pin not defined");
+                    return;
+                }
+                _cs_pin.setAttr(Pin::Attr::Output);
+                SPI.begin();
+                _gpio_ok = true;
+                setupSpeeds(4095);
+                break;
         }
 
         _enable_pin.setAttr(Pin::Attr::Output);
@@ -39,7 +66,6 @@ namespace Spindles {
         if (_speeds.size() == 0) {
             linearSpeeds(10000, 100.0f);
         }
-        setupSpeeds(255);
 
         init_atc();
         config_message();
@@ -47,18 +73,52 @@ namespace Spindles {
 
     void Dac::config_message() {
         log_info(name() << " Spindle Ena:" << _enable_pin.name() << " Out:" << _output_pin.name() << " Dir:" << _direction_pin.name()
-                        << " Res:8bits" << atc_info());
+                        << " Mode:" << (_mode == Internal ? "internal" : (_mode == PWM ? "pwm" : "mcp4822")) << atc_info());
     }
 
     void IRAM_ATTR Dac::setSpeedfromISR(uint32_t speed) {
         set_output(speed);
     };
     void IRAM_ATTR Dac::set_output(uint32_t duty) {
-        if (_gpio_ok) {
-            auto outputNative = _output_pin.getNative(Pin::Capabilities::DAC);
-
-            dacWrite(outputNative, static_cast<uint8_t>(duty));
+        if (!_gpio_ok) {
+            return;
         }
+
+        switch (_mode) {
+            case Internal: {
+                auto outputNative = _output_pin.getNative(Pin::Capabilities::DAC);
+                dacWrite(outputNative, static_cast<uint8_t>(duty));
+                break;
+            }
+            case PWM:
+                _output_pin.setDuty(duty);
+                break;
+            case MCP4822: {
+                uint16_t value = 0x3000 | (_mcp_channel ? 0x8000 : 0) | (duty & 0x0FFF);
+                _cs_pin.off();
+                SPI.transfer16(value);
+                _cs_pin.on();
+                break;
+            }
+        }
+    }
+
+    const EnumItem dacModeItems[] = {
+        { Dac::Internal, "internal" },
+        { Dac::MCP4822, "mcp4822" },
+        { Dac::PWM, "pwm" },
+        EnumItem(Dac::Internal)
+    };
+
+    void Dac::group(Configuration::HandlerBase& handler) {
+        handler.item("mode", _mode, dacModeItems);
+        if (_mode == PWM) {
+            handler.item("pwm_hz", _pwm_freq, 1, 20000000);
+        } else if (_mode == MCP4822) {
+            handler.item("cs_pin", _cs_pin);
+            handler.item("mcp_channel", _mcp_channel, 0, 1);
+        }
+        OnOff::group(handler);
     }
 
     // Configuration registration
@@ -66,4 +126,3 @@ namespace Spindles {
         SpindleFactory::InstanceBuilder<Dac> registration("DAC");
     }
 }
-#endif

--- a/FluidNC/tests/DacSpindleScalingTest.cpp
+++ b/FluidNC/tests/DacSpindleScalingTest.cpp
@@ -1,0 +1,63 @@
+#include "gtest/gtest.h"
+#include <vector>
+
+struct speedEntry {
+    uint32_t speed;
+    float    percent;
+    uint32_t offset;
+    uint32_t scale;
+};
+
+static void setupSpeeds(std::vector<speedEntry>& speeds, uint32_t max_dev_speed) {
+    int nsegments = speeds.size() - 1;
+    if (nsegments < 1) {
+        return;
+    }
+    for (int i = 0; i < nsegments; ++i) {
+        speeds[i].offset = speeds[i].percent / 100.0f * max_dev_speed;
+        float deltaPercent = (speeds[i + 1].percent - speeds[i].percent) / 100.0f;
+        float deltaRPM     = speeds[i + 1].speed - speeds[i].speed;
+        float scale        = deltaRPM == 0.0f ? 0.0f : (deltaPercent / deltaRPM);
+        scale *= max_dev_speed;
+        speeds[i].scale = uint32_t(scale * 65536);
+    }
+    speeds[nsegments].offset = speeds[nsegments].percent / 100.0f * max_dev_speed;
+    speeds[nsegments].scale  = 0;
+}
+
+static uint32_t mapSpeed(const std::vector<speedEntry>& speeds, uint32_t speed) {
+    if (speeds.empty()) {
+        return 0;
+    }
+    if (speed < speeds[0].speed) {
+        return speeds[0].offset;
+    }
+    int num_segments = speeds.size() - 1;
+    int i;
+    for (i = 0; i < num_segments; i++) {
+        if (speed < speeds[i + 1].speed) {
+            break;
+        }
+    }
+    uint32_t dev_speed = speeds[i].offset;
+    if (i < num_segments) {
+        dev_speed += uint32_t(((speed - speeds[i].speed) * uint64_t(speeds[i].scale)) >> 16);
+    }
+    return dev_speed;
+}
+
+TEST(DacSpindleScaling, LinearMapping8Bit) {
+    std::vector<speedEntry> speeds = { {0,0}, {1000,100} };
+    setupSpeeds(speeds, 255);
+    EXPECT_EQ(mapSpeed(speeds,0), 0u);
+    EXPECT_NEAR(mapSpeed(speeds,500), 127u, 1u);
+    EXPECT_EQ(mapSpeed(speeds,1000), 255u);
+}
+
+TEST(DacSpindleScaling, LinearMapping12Bit) {
+    std::vector<speedEntry> speeds = { {0,0}, {1000,100} };
+    setupSpeeds(speeds, 4095);
+    EXPECT_EQ(mapSpeed(speeds,0), 0u);
+    EXPECT_NEAR(mapSpeed(speeds,500), 2047u, 2u);
+    EXPECT_EQ(mapSpeed(speeds,1000), 4095u);
+}

--- a/X86TestSupport/TestSupport/driver/SPI.cpp
+++ b/X86TestSupport/TestSupport/driver/SPI.cpp
@@ -1,0 +1,3 @@
+#include "SPI.h"
+
+SPIClass SPI;

--- a/X86TestSupport/TestSupport/driver/SPI.h
+++ b/X86TestSupport/TestSupport/driver/SPI.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <cstdint>
+
+class SPIClass {
+public:
+    void begin() {}
+    uint16_t transfer16(uint16_t value) { return value; }
+};
+
+extern SPIClass SPI;

--- a/docs/dac_spindle.md
+++ b/docs/dac_spindle.md
@@ -1,0 +1,24 @@
+# DAC Spindle
+
+Provides analogue spindle speed control using one of three backends:
+
+- **internal** – uses ESP32 built-in DAC on pins 25 or 26.
+- **mcp4822** – drives an external MCP4822 12‑bit SPI DAC.
+- **pwm** – outputs PWM that can be filtered by an RC network to obtain a voltage.
+
+## Configuration
+
+```yaml
+spindle:
+  name: DAC
+  type: DAC
+  enable_pin: gpio.2
+  output_pin: gpio.25    # unused when mode=mcp4822
+  mode: internal         # internal, mcp4822 or pwm
+  pwm_hz: 5000           # only for pwm mode
+  cs_pin: gpio.5         # only for mcp4822 mode
+  mcp_channel: 0         # 0 or 1 for mcp4822 mode
+```
+
+The speed map determines how G-code `S` values map to output voltage. When
+unspecified it defaults to a linear 0–10000 rpm map.


### PR DESCRIPTION
## Summary
- extend DAC spindle to support internal, MCP4822, or PWM backends
- document DAC spindle configuration and hardware options
- add tests validating linear speed scaling

## Testing
- `pio test -e tests`

------
https://chatgpt.com/codex/tasks/task_e_68b6af02a2108333982a57a7cb433961