### PR TITLE
Enable 16MB flash and PSRAM for ESP32-S3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -89,6 +89,10 @@ board = esp32dev
 [common_esp32_s3]
 extends = common_esp32_base
 board = esp32-s3-devkitc-1
+; Settings compatible with ESP32-S3 N16R8 module (16MB flash / 8MB PSRAM)
+board_build.flash_size = 16MB
+board_upload.flash_size = 16MB
+board_build.psram = enabled
 lib_deps = ${common.lib_deps}
 
 [common_wifi]


### PR DESCRIPTION
## Summary
- configure ESP32-S3 builds for 16MB flash and PSRAM
- note compatibility with ESP32-S3 N16R8 module

## Testing
- `platformio run -e wifi_s3` *(fails: 'I2S0O_DATA_OUT23_IDX' undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b72ca9d0833390ef62eedd62b32b