### PR TITLE
chore: pin esp32-s3 platform

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -88,6 +88,7 @@ board = esp32dev
 
 [common_esp32_s3]
 extends = common_esp32_base
+platform = espressif32@6.8.0
 board = esp32-s3-devkitc-1
 ; Settings compatible with ESP32-S3 N16R8 module (16MB flash / 8MB PSRAM)
 board_build.flash_size = 16MB


### PR DESCRIPTION
## Summary
- specify espressif32@6.8.0 for ESP32-S3 builds

## Testing
- `platformio run -e wifi_s3` (fails: I2S0O_DATA_OUT23_IDX undeclared)
- `platformio run -e wifi` (fails: Spindles::Dac::Mode Internal is private)


------
https://chatgpt.com/codex/tasks/task_e_68b707d9b1d08333a026edaaacf62b32