### PR TITLE
Add ESP32-S3 DevKitC N16R8 board config

### DIFF
--- a/boards/esp32s3-devkitc-1-n16r8.json
+++ b/boards/esp32s3-devkitc-1-n16r8.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      ["0x303A", "0x1001"]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": ["bluetooth", "wifi"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "Espressif ESP32-S3-DevKitC-1-N16R8 (16 MB QD, 8 MB OPI PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -138,6 +138,15 @@ extends = common_esp32_s3
 lib_deps = ${common.lib_deps} ${common.bt_deps}
 build_src_filter = ${common_esp32_base.build_src_filter} ${common_bt.build_src_filter}
 
+
+[env:esp32s3-devkitc-1-n16r8]
+extends = common_esp32_s3
+board = esp32s3-devkitc-1-n16r8
+lib_deps = ${common.lib_deps}
+build_src_filter = ${common_esp32_base.build_src_filter} -<esp32/i2s_engine.c> -<src/Spindles/DacSpindle.cpp> -<src/Machine/I2SOBus.cpp> -<src/Pins/I2SOPinDetail.cpp>
+build_flags = ${common_esp32_base.build_flags} -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=0 -DCONFIG_IDF_TARGET_ESP32S3
+
+
 ; This environment has bit-rot, and does not build.
 ; Files relevant to it reside in ./X86TestSupport and ./FluidNC/test
 ; TODO - Migrate tests over to [env:tests] environment


### PR DESCRIPTION
## Summary
- add ESP32-S3 DevKitC N16R8 board definition with 16MB flash, 8MB OPI PSRAM and USB-CDC flags
- provide new PlatformIO environment using the board and required USB build flags

## Testing
- `pio run -e esp32s3-devkitc-1-n16r8` *(fails: undefined reference to Machine::I2SOBus and Pins::I2SOPinDetail)*

------
https://chatgpt.com/codex/tasks/task_e_68b7df724fc08333a8b9632c71b6c9af