### PR TITLE
Add ESP32-S3 DevKitC-1 pin map and configurable LED

### DIFF
--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -25,6 +25,10 @@
 
 #    include "src/ToolChangers/atc.h"
 
+#    if CONFIG_IDF_TARGET_ESP32S3
+#        include "boards/esp32s3_devkitc_1.h"
+#    endif
+
 extern void make_user_commands();
 
 void setup() {
@@ -34,6 +38,10 @@ void setup() {
         uartInit();  // Setup serial port
 
         StartupLog::init();
+
+#if CONFIG_IDF_TARGET_ESP32S3
+        s3_board_setup();
+#endif
 
         // Setup input polling loop after loading the configuration,
         // because the polling may depend on the config

--- a/FluidNC/src/boards/esp32s3_devkitc_1.h
+++ b/FluidNC/src/boards/esp32s3_devkitc_1.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// Pin definitions for ESP32-S3 DevKitC-1 board.
+// GPIO35, GPIO36 and GPIO37 are absent on this module and must not be used.
+
+// Axis X pins
+#define X_STEP_PIN        2
+#define X_DIRECTION_PIN   3
+#define X_DISABLE_PIN     4
+#define X_LIMIT_NEG_PIN   16
+
+// Axis Y pins
+#define Y_STEP_PIN        5
+#define Y_DIRECTION_PIN   6
+#define Y_DISABLE_PIN     7
+#define Y_LIMIT_NEG_PIN   17
+// Second motor on Y (Y2)
+#define Y2_STEP_PIN       8
+#define Y2_DIRECTION_PIN  9
+#define Y2_DISABLE_PIN    10
+
+// Axis Z pins
+#define Z_STEP_PIN        11
+#define Z_DIRECTION_PIN   12
+#define Z_DISABLE_PIN     13
+#define Z_LIMIT_NEG_PIN   18
+
+// Probe and toolsetter
+#define PROBE_PIN         21
+#define TOOLSETTER_PIN    33
+
+// Spindle control
+#define SPINDLE_PWM_PIN   14
+#define SPINDLE_ENABLE_PIN 15
+
+// Coolant control
+#define COOLANT_MIST_PIN  22
+#define COOLANT_FLOOD_PIN 23
+
+// Default on-board LED pin. Can be overridden at build time with -DS3_BOARD_LED_PIN=<gpio>.
+#ifndef S3_BOARD_LED_PIN
+#    define S3_BOARD_LED_PIN 38
+#endif
+
+#include <Arduino.h>
+#include "../Logging.h"
+
+// Initialize board-specific hardware like the status LED.
+// Nastavenie vstavaného LED pinu ako výstup a vypnutie LED.
+inline void s3_board_setup() {
+    pinMode(S3_BOARD_LED_PIN, OUTPUT);     // nastav LED pin ako výstup
+    digitalWrite(S3_BOARD_LED_PIN, LOW);   // vypni LED pri štarte
+    log_info("S3 board LED on GPIO" << S3_BOARD_LED_PIN);
+}
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ ESP32‑S3 boards must provide 16 MB flash and 8 MB PSRAM. The S3 offers onl
 
 An [ESP32‑S3 example configuration](https://github.com/bdring/fluidnc-config-files/blob/main/official/esp32-s3-example.yaml) is available for reference.
 
+The DevKitC‑1 board exposes an on‑board status LED on **GPIO38**. The firmware uses the `S3_BOARD_LED_PIN` macro (default 38) to configure this LED at start-up; override it via a build flag if your design uses a different pin. Pins **GPIO35–GPIO37** are unavailable on ESP32‑S3 modules and should be avoided in configurations.
+
 ## Basic Grbl Compatibility
 
 The intent is to maintain as much Grbl compatibility as possible. It is 100% compatible with the day to day operations of running gcode with a sender, so there is no change to the Grbl gcode send/response protocol, and all Grbl gcode are supported. Most of the $ settings have been replaced with easily readable items in the config file.

--- a/example_configs/4x_2209_atc.yaml
+++ b/example_configs/4x_2209_atc.yaml
@@ -35,7 +35,7 @@ axes:
       seek_mm_per_min: 1500
       feed_mm_per_min: 700
     motor0:
-      limit_neg_pin: gpio.35:low
+      limit_neg_pin: gpio.27:low
       limit_pos_pin: NO_PIN
       limit_all_pin: NO_PIN
       pulloff_mm: 2
@@ -133,7 +133,7 @@ control:
   cycle_start_pin: NO_PIN
 
 probe:
-  pin: gpio.36:low
+  pin: gpio.15:low
   toolsetter_pin: gpio.33:low:pu
 spi:
   miso_pin: gpio.19

--- a/example_configs/4x_2209_atc_class.yaml
+++ b/example_configs/4x_2209_atc_class.yaml
@@ -35,7 +35,7 @@ axes:
       seek_mm_per_min: 1500
       feed_mm_per_min: 700
     motor0:
-      limit_neg_pin: gpio.35:low
+      limit_neg_pin: gpio.27:low
       limit_pos_pin: NO_PIN
       limit_all_pin: NO_PIN
       hard_limits: true
@@ -134,7 +134,7 @@ control:
   cycle_start_pin: NO_PIN
 
 probe:
-  pin: gpio.36:low
+  pin: gpio.15:low
   toolsetter_pin: gpio.33:low:pu
 spi:
   miso_pin: gpio.19

--- a/example_configs/4x_2209a_atc_class.yaml
+++ b/example_configs/4x_2209a_atc_class.yaml
@@ -35,7 +35,7 @@ axes:
       seek_mm_per_min: 1500
       feed_mm_per_min: 700
     motor0:
-      limit_neg_pin: gpio.35:low
+      limit_neg_pin: gpio.27:low
       limit_pos_pin: NO_PIN
       limit_all_pin: NO_PIN
       hard_limits: true
@@ -170,7 +170,7 @@ control:
   cycle_start_pin: NO_PIN
 
 probe:
-  pin: gpio.36:low
+  pin: gpio.15:low
   toolsetter_pin: gpio.33:low:pu
 spi:
   miso_pin: gpio.19


### PR DESCRIPTION
## Summary
- add `esp32s3_devkitc_1` board header with pin map and configurable `S3_BOARD_LED_PIN`
- init board LED during startup for ESP32-S3
- remove restricted GPIO35-37 usage from sample configs and document LED macro

## Testing
- `pio run -e esp32s3-devkitc-1-n16r8` *(fails: undefined reference to Machine::I2SOBus)*
- `pio test -e tests_nosan`


------
https://chatgpt.com/codex/tasks/task_e_68b80ce505bc833395d6fd40fc320981