### PR TITLE
Align ESP32-S3 USB CDC defaults

### DIFF
--- a/FluidNC/src/UartChannel.cpp
+++ b/FluidNC/src/UartChannel.cpp
@@ -4,6 +4,7 @@
 #include "UartChannel.h"
 #include "Machine/MachineConfig.h"  // config
 #include "Serial.h"                 // allChannels
+#include <Arduino.h>                 // Serial, USB-CDC
 
 UartChannel::UartChannel(int num, bool addCR) : Channel("uart_channel", num, addCR) {
     _lineedit = new Lineedit(this, _line, Channel::maxLine - 1);
@@ -171,9 +172,15 @@ bool UartChannel::setAttr(int index, bool* value, const std::string& attrString)
     return false;
 }
 
+// Uart0 uses Serial/Serial0 mapped to USB-CDC; additional UARTs use Serial1 with explicit GPIOs.
 UartChannel Uart0(0, true);  // Primary serial channel with LF to CRLF conversion
 
 void uartInit() {
+    // Initialize USB-CDC so Serial/Serial0 is available on the USB port.
+#if ARDUINO_USB_CDC_ON_BOOT
+    Serial.begin(BAUD_RATE);  // Inicializuj USB-CDC port
+#endif
+
     auto uart0 = new Uart(0);
     uart0->begin(BAUD_RATE, UartData::Bits8, UartStop::Bits1, UartParity::None);
     Uart0.init(uart0);

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ platformio run -e wifi_s3 -t upload
 platformio run -e noradio_s3 -t upload
 ```
 
+#### Monitor
+
+Use PlatformIO's USB monitor to watch the USB‑CDC console:
+
+```bash
+pio device monitor -p usb -b 115200
+```
+
 ESP32‑S3 boards must provide 16 MB flash and 8 MB PSRAM. The S3 offers only four RMT channels and lacks an internal DAC, so analog spindle output requires an external device.
 
 An [ESP32‑S3 example configuration](https://github.com/bdring/fluidnc-config-files/blob/main/official/esp32-s3-example.yaml) is available for reference.

--- a/boards/esp32s3-devkitc-1-n16r8.json
+++ b/boards/esp32s3-devkitc-1-n16r8.json
@@ -8,7 +8,7 @@
     "core": "esp32",
     "extra_flags": [
       "-DARDUINO_ESP32S3_DEV",
-      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_MODE=0",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1",

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,6 +95,7 @@ board_build.flash_size = 16MB
 board_upload.flash_size = 16MB
 board_build.psram = enabled
 lib_deps = ${common.lib_deps}
+build_flags = ${common_esp32_base.build_flags} -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=0 -DCONFIG_IDF_TARGET_ESP32S3
 
 [common_wifi]
 build_src_filter = +<src/WebUI/*.cpp>
@@ -126,7 +127,6 @@ build_src_filter = ${common_esp32_base.build_src_filter} ${common_bt.build_src_f
 extends = common_esp32_s3
 lib_deps = ${common.lib_deps}
 build_src_filter = ${common_esp32_base.build_src_filter}
-build_flags = ${common_esp32_base.build_flags}
 
 [env:wifi_s3]
 extends = common_esp32_s3
@@ -144,7 +144,6 @@ extends = common_esp32_s3
 board = esp32s3-devkitc-1-n16r8
 lib_deps = ${common.lib_deps}
 build_src_filter = ${common_esp32_base.build_src_filter} -<esp32/i2s_engine.c> -<src/Spindles/DacSpindle.cpp> -<src/Machine/I2SOBus.cpp> -<src/Pins/I2SOPinDetail.cpp>
-build_flags = ${common_esp32_base.build_flags} -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=0 -DCONFIG_IDF_TARGET_ESP32S3
 
 
 ; This environment has bit-rot, and does not build.


### PR DESCRIPTION
## Summary
- propagate ARDUINO_USB_CDC_ON_BOOT=1 and ARDUINO_USB_MODE=0 across all S3 build environments
- ensure `uartInit` brings up USB‑CDC Serial and document use of Serial1 for extra UARTs
- add README note for monitoring via `pio device monitor -p usb -b 115200`

## Testing
- `pio run -e noradio_s3` *(fails: i2s_engine.c:32:31: error: 'I2S_TX_DATA_NUM' undeclared)*
- `pio run -e esp32s3-devkitc-1-n16r8` *(fails: undefined reference to Machine::I2SOBus)*

------
https://chatgpt.com/codex/tasks/task_e_68b81bffa9788333b4f9f0271b8bbffb