### PR TITLE
Abstract HAL macros for ESP32 variants

### DIFF
--- a/FluidNC/esp32/PwmPin.cpp
+++ b/FluidNC/esp32/PwmPin.cpp
@@ -7,6 +7,7 @@
 
 #include "Driver/PwmPin.h"
 #include "src/Config.h"
+#include "hal_target.h"
 
 #include <soc/ledc_struct.h>  // LEDC
 
@@ -25,7 +26,7 @@
 #    include "esp32/rom/gpio.h"
 #elif CONFIG_IDF_TARGET_ESP32S2
 #    include "esp32s2/rom/gpio.h"
-#elif CONFIG_IDF_TARGET_ESP32S3
+#elif HAL_TARGET_ESP32S3
 #    include "esp32s3/rom/gpio.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
 #    include "esp32c3/rom/gpio.h"

--- a/FluidNC/esp32/README.md
+++ b/FluidNC/esp32/README.md
@@ -1,0 +1,11 @@
+# ESP32 HAL helpers
+
+This directory contains low level helpers for ESP32 targets.  
+`hal_target.h` defines compile-time macros describing chip features:
+
+- `HAL_HAS_DAC` – on chips without DAC the value is `0`.
+- `HAL_HAS_APLL` – indicates availability of the Audio PLL.
+- `HAL_RMT_TX_MAX` – maximum number of RMT TX channels.
+
+Use these macros instead of raw `CONFIG_IDF_TARGET_*` checks to keep
+drivers portable between ESP32 variants.

--- a/FluidNC/esp32/delay_usecs.cpp
+++ b/FluidNC/esp32/delay_usecs.cpp
@@ -4,12 +4,13 @@
 #include <xtensa/core-macros.h>
 
 #include <sdkconfig.h>
+#include "hal_target.h"
 
 #if CONFIG_IDF_TARGET_ESP32
 #    include "esp32/clk.h"
 #elif CONFIG_IDF_TARGET_ESP32S2
 #    include "esp32s2/clk.h"
-#elif CONFIG_IDF_TARGET_ESP32S3
+#elif HAL_TARGET_ESP32S3
 #    include "esp32s3/clk.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
 #    include "esp32c3/clk.h"

--- a/FluidNC/esp32/fnc_idf_uart.c
+++ b/FluidNC/esp32/fnc_idf_uart.c
@@ -25,12 +25,13 @@
 #include "driver/periph_ctrl.h"
 #include "sdkconfig.h"
 #include "esp_rom_gpio.h"
+#include "hal_target.h"
 
 #if CONFIG_IDF_TARGET_ESP32
 #    include "esp32/clk.h"
 #elif CONFIG_IDF_TARGET_ESP32S2
 #    include "esp32s2/clk.h"
-#elif CONFIG_IDF_TARGET_ESP32S3
+#elif HAL_TARGET_ESP32S3
 #    include "esp32s3/clk.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
 #    include "esp32c3/clk.h"

--- a/FluidNC/esp32/hal_target.h
+++ b/FluidNC/esp32/hal_target.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// Hardware abstraction for ESP32 variants.
+// Provides macros describing peripheral availability.
+
+#if defined(HAL_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32S3)
+#define HAL_TARGET_ESP32S3 1
+#define HAL_TARGET_ESP32 0
+#define HAL_HAS_DAC 0       // ESP32-S3 nemá interný DAC
+#define HAL_HAS_APLL 0      // ESP32-S3 nepodporuje APLL
+#define HAL_RMT_TX_MAX 4    // ESP32-S3 má 4 RMT TX kanály
+#else
+#define HAL_TARGET_ESP32S3 0
+#define HAL_TARGET_ESP32 1
+#define HAL_HAS_DAC 1       // ESP32 obsahuje DAC
+#define HAL_HAS_APLL 1      // ESP32 podporuje APLL
+#define HAL_RMT_TX_MAX 8    // ESP32 má 8 RMT TX kanálov
+#endif
+

--- a/FluidNC/esp32/i2s_engine.c
+++ b/FluidNC/esp32/i2s_engine.c
@@ -37,6 +37,7 @@
 #include "Driver/delay_usecs.h"  // delay_us()
 
 #include <esp_attr.h>  // IRAM_ATTR
+#include "hal_target.h"
 
 #include <freertos/FreeRTOS.h>
 
@@ -295,7 +296,7 @@ int i2s_out_init(i2s_out_init_t* init_param) {
     i2s_ll_tx_enable_msb_shift(&I2S0, false);  // Do not use the Philips standard to avoid bit-shifting
 
     // clang-format off
-#if !CONFIG_IDF_TARGET_ESP32S3
+#if HAL_HAS_APLL
     // Classic ESP32: use the Audio PLL for precise stepping timings
     i2s_ll_tx_clk_set_src(&I2S0, I2S_CLK_APLL);
 #else

--- a/FluidNC/esp32/rmt_engine.c
+++ b/FluidNC/esp32/rmt_engine.c
@@ -85,17 +85,10 @@ static IRAM_ATTR void start_step() {}
 
 // Restart the RMT which has already been configured
 // for the desired pulse length, polarity, and direction delay
+// Start prepared RMT transaction for a step pulse
+// Spúšťa pripravený RMT prenos pre krokový impulz
 static IRAM_ATTR void set_step_pin(int pin, int level) {
-#ifdef CONFIG_IDF_TARGET_ESP32
-    RMT.conf_ch[pin].conf1.mem_rd_rst = 1;
-    RMT.conf_ch[pin].conf1.mem_rd_rst = 0;
-    RMT.conf_ch[pin].conf1.tx_start   = 1;
-#endif
-#ifdef CONFIG_IDF_TARGET_ESP32S3
-    RMT.chnconf0[pin].mem_rd_rst_n = 1;
-    RMT.chnconf0[pin].mem_rd_rst_n = 0;
-    RMT.chnconf0[pin].tx_start_n   = 1;
-#endif
+    hal_rmt_start_tx(pin, level);
 }
 
 // This is a noop because the RMT channels do everything

--- a/FluidNC/esp32/rmt_hal.h
+++ b/FluidNC/esp32/rmt_hal.h
@@ -1,21 +1,19 @@
 #pragma once
 
-#ifdef CONFIG_IDF_TARGET_ESP32S3
+#include "hal_target.h"
+
+// Define human-readable target name
+#if HAL_TARGET_ESP32S3
 #define RMT_TARGET_STRING "ESP32-S3"
-#ifdef __cplusplus
-// Maximum number of RMT TX channels for ESP32-S3
-constexpr int kMaxRmtTx = 4;
-#else
-#define kMaxRmtTx 4
-#endif
 #else
 #define RMT_TARGET_STRING "ESP32"
-#ifdef __cplusplus
-// Maximum number of RMT TX channels for other ESP32 targets
-constexpr int kMaxRmtTx = 8;
-#else
-#define kMaxRmtTx 8
 #endif
+
+#ifdef __cplusplus
+// Maximum number of RMT TX channels for the active target
+constexpr int kMaxRmtTx = HAL_RMT_TX_MAX;
+#else
+#define kMaxRmtTx HAL_RMT_TX_MAX
 #endif
 
 #ifdef __cplusplus
@@ -32,3 +30,11 @@ inline std::string RmtAxisLimitMsg(int configured) {
 }
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Start RMT transmission on given channel
+void hal_rmt_start_tx(int pin, int level);
+#ifdef __cplusplus
+}
+#endif

--- a/FluidNC/esp32/rmt_start_tx_esp32.c
+++ b/FluidNC/esp32/rmt_start_tx_esp32.c
@@ -1,0 +1,16 @@
+// RMT start for classic ESP32
+// Štart prenosu pre klasické ESP32
+
+#include "hal_target.h"
+#if HAL_TARGET_ESP32
+#include <driver/rmt.h>
+
+// Trigger RMT transmission on configured channel
+// Spustí prenos na kanáli nakonfigurovanom v RMT
+void hal_rmt_start_tx(int pin, int level) {
+    (void)level; // Level not used, waveform already prepared
+    RMT.conf_ch[pin].conf1.mem_rd_rst = 1;
+    RMT.conf_ch[pin].conf1.mem_rd_rst = 0;
+    RMT.conf_ch[pin].conf1.tx_start   = 1;
+}
+#endif

--- a/FluidNC/esp32/rmt_start_tx_esp32s3.c
+++ b/FluidNC/esp32/rmt_start_tx_esp32s3.c
@@ -1,0 +1,16 @@
+// RMT start for ESP32-S3
+// Štart prenosu pre ESP32-S3
+
+#include "hal_target.h"
+#if HAL_TARGET_ESP32S3
+#include <driver/rmt.h>
+
+// Trigger RMT transmission on configured channel
+// Spustí prenos na kanáli nakonfigurovanom v RMT
+void hal_rmt_start_tx(int pin, int level) {
+    (void)level; // Level not used, waveform already prepared
+    RMT.chnconf0[pin].mem_rd_rst_n = 1;
+    RMT.chnconf0[pin].mem_rd_rst_n = 0;
+    RMT.chnconf0[pin].tx_start_n   = 1;
+}
+#endif

--- a/FluidNC/esp32/spi.cpp
+++ b/FluidNC/esp32/spi.cpp
@@ -8,8 +8,9 @@
 #include "src/Config.h"
 
 #include <sdkconfig.h>
+#include "hal_target.h"
 
-#ifdef CONFIG_IDF_TARGET_ESP32S3
+#if HAL_TARGET_ESP32S3
 #    define HSPI_HOST SPI2_HOST
 #endif
 

--- a/FluidNC/esp32/tmc_spi_support.c
+++ b/FluidNC/esp32/tmc_spi_support.c
@@ -9,7 +9,8 @@
 #include "hal/spi_ll.h"
 
 #include <sdkconfig.h>
-#ifdef CONFIG_IDF_TARGET_ESP32S3
+#include "hal_target.h"
+#if HAL_TARGET_ESP32S3
 #    define HSPI_HOST SPI2_HOST
 #    define SPI2 GPSPI2
 #endif

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -24,8 +24,9 @@
 #    include "esp32-hal.h"  // disableCore0WDT
 
 #    include "src/ToolChangers/atc.h"
+#    include "esp32/hal_target.h"
 
-#    if CONFIG_IDF_TARGET_ESP32S3
+#    if HAL_TARGET_ESP32S3
 #        include "boards/esp32s3_devkitc_1.h"
 #    endif
 
@@ -39,7 +40,7 @@ void setup() {
 
         StartupLog::init();
 
-#if CONFIG_IDF_TARGET_ESP32S3
+#if HAL_TARGET_ESP32S3
         s3_board_setup();
 #endif
 

--- a/FluidNC/src/Spindles/DacSpindle.cpp
+++ b/FluidNC/src/Spindles/DacSpindle.cpp
@@ -11,6 +11,7 @@
 #include "DacSpindle.h"
 
 #include <sdkconfig.h>
+#include "esp32/hal_target.h"
 
 #include <cstdint>
 
@@ -125,9 +126,7 @@ namespace Spindles {
 
     // Configuration registration
     namespace {
-#ifdef CONFIG_IDF_TARGET_ESP32S3
-    // DAC spindle replaced by LEDC on ESP32-S3
-#else
+#if HAL_HAS_DAC
         SpindleFactory::InstanceBuilder<Dac> registration("DAC");
 #endif
     }

--- a/FluidNC/src/Spindles/LedcSpindle.cpp
+++ b/FluidNC/src/Spindles/LedcSpindle.cpp
@@ -12,6 +12,7 @@
 
 #include <Arduino.h>
 #include <sdkconfig.h>
+#include "esp32/hal_target.h"
 
 namespace Spindles {
     // =========================== Ledc ============================
@@ -76,7 +77,7 @@ namespace Spindles {
 
     // Configuration registration
     namespace {
-    #ifdef CONFIG_IDF_TARGET_ESP32S3
+    #if !HAL_HAS_DAC
         SpindleFactory::InstanceBuilder<Ledc> registration("DAC");
     #endif
     }

--- a/FluidNC/tests/RmtChannelLimitTest.cpp
+++ b/FluidNC/tests/RmtChannelLimitTest.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#define CONFIG_IDF_TARGET_ESP32S3
+#define HAL_TARGET_ESP32S3 1
 #include "../esp32/rmt_hal.h"
 
 // Verify log message when too many axes are configured


### PR DESCRIPTION
## Summary
- add `hal_target.h` with macros for DAC, APLL and RMT channel count
- split RMT transmit kick-off into ESP32 and ESP32-S3 files
- replace `CONFIG_IDF_TARGET_ESP32S3` checks with HAL macros across drivers

## Testing
- `pio test -e tests`


------
https://chatgpt.com/codex/tasks/task_e_68b81f3d41948333ae8d1ad45ed13dca