### PR TITLE
docs: add ESP32-S3 quickstart

### DIFF
--- a/README-S3.md
+++ b/README-S3.md
@@ -1,0 +1,47 @@
+# ESP32-S3 Quickstart
+
+## Flashing
+
+1. Connect the ESP32-S3 via USB.
+2. Build and upload the firmware:
+   ```bash
+   pio run -e esp32s3-devkitc-1-n16r8 -t upload
+   ```
+3. After upload completes, reset the board.
+
+## USB-CDC Console
+
+Access the serial console over the native USB-CDC interface:
+```bash
+pio device monitor -p usb -b 115200
+```
+
+## PWM Spindle Verification
+
+1. Enable PWM spindle output in your configuration.
+2. Send a spindle command and measure the output pin with a multimeter or scope:
+   ```gcode
+   M3 S1000
+   ```
+3. Use `M5` to stop the spindle.
+
+## RMT Channel Limits
+
+ESP32-S3 offers **four** RMT channels. Each PWM, step generator, or other RMT-based feature consumes one channel. Plan pin assignments so the total RMT usage does not exceed four channels.
+
+## Quick Test
+
+### Compile Only
+```bash
+pio run -e esp32s3-devkitc-1-n16r8
+```
+
+### Minimal G-code Exercise
+Use the USB-CDC console or Web UI to send:
+```gcode
+G0 X10 Y10
+M3 S5000
+G1 X0 Y0 F1000
+M5
+```
+This moves the machine in a square and toggles the spindle.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ ESP32‑S3 boards must provide 16 MB flash and 8 MB PSRAM. The S3 offers onl
 
 An [ESP32‑S3 example configuration](https://github.com/bdring/fluidnc-config-files/blob/main/official/esp32-s3-example.yaml) is available for reference.
 
+See [README-S3](README-S3.md) for flashing, USB-CDC usage, and quick test steps.
+
 The DevKitC‑1 board exposes an on‑board status LED on **GPIO38**. The firmware uses the `S3_BOARD_LED_PIN` macro (default 38) to configure this LED at start-up; override it via a build flag if your design uses a different pin. Pins **GPIO35–GPIO37** are unavailable on ESP32‑S3 modules and should be avoided in configurations.
 
 ## Basic Grbl Compatibility


### PR DESCRIPTION
## Summary
- document ESP32-S3 flashing, USB-CDC console, PWM spindle checks, and RMT limits
- link quickstart guide from README

## Testing
- `pio run -e esp32s3-devkitc-1-n16r8` *(fails: undefined reference to `Machine::I2SOBus`)*

------
https://chatgpt.com/codex/tasks/task_e_68b877e14c5c8333a1eb885c879fe55a